### PR TITLE
add riscv64, loongarch64, ppc64le and ppc64 builds

### DIFF
--- a/.github/workflows/appimage-nightly.yml
+++ b/.github/workflows/appimage-nightly.yml
@@ -18,18 +18,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs-on: ubuntu-latest
-            name: Build AppImage
-            arch: x86_64
-          # comment out these 3 lines if aarch64 is not wanted
-          - runs-on: ubuntu-24.04-arm
-            name: Build AppImage
-            arch: aarch64
+          - { runs-on: ubuntu-latest, name: Build AppImage, arch: x86_64 }
+          # comment out this line if aarch64 is not wanted
+          - { runs-on: ubuntu-24.04-arm, name: Build AppImage, arch: aarch64 }
     container: ghcr.io/pkgforge-dev/archlinux:latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Preparing Container
-        uses: pkgforge-dev/anylinux-setup-action@0964f2258d6c93d1391359978dde081fd8b3c6af # v2
+        uses: pkgforge-dev/anylinux-setup-action@7278cbb7c3692fce7241d427614ef7984192f138 # v3
       - name: Install Dependencies
         run: DEVEL_RELEASE=1 /bin/sh ./get-dependencies.sh
       - name: Make AppImage
@@ -40,9 +36,44 @@ jobs:
           name: AppImage-${{ matrix.arch }}
           path: dist
 
+  # riscv64, loongarch64, ppc64le and ppc64 have no native runners, they build
+  # in the same container under qemu user emulation. comment out a line in the
+  # matrix to drop one arch, or set `if:` to false to turn the whole job off
+  build-additional-cpu-arches:
+    if: true
+    name: "${{ matrix.name }} (${{ matrix.arch }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: Build AppImage, arch: riscv64, platform: linux/riscv64 }
+          - { name: Build AppImage, arch: loongarch64, platform: linux/loong64 }
+          - { name: Build AppImage, arch: ppc64le, platform: linux/ppc64le }
+          # powerpc64 is big endian, uname -m reports ppc64
+          - { name: Build AppImage, arch: ppc64, platform: linux/ppc64 }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Build AppImage (emulated)
+        uses: pkgforge-dev/anylinux-setup-action/emulated@7278cbb7c3692fce7241d427614ef7984192f138 # v3
+        with:
+          platform: ${{ matrix.platform }}
+        env:
+          DEVEL_RELEASE: 1
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: AppImage-${{ matrix.arch }}
+          path: dist
+
   release:
-    if: ${{ github.ref_name == 'main' }}
-    needs: [build]
+    # !cancelled() is what lets the release still happen when the job above is
+    # switched off, a skipped dependency otherwise skips this job too
+    if: >-
+      ${{ !cancelled() && github.ref_name == 'main'
+      && needs.build.result == 'success'
+      && needs.build-additional-cpu-arches.result != 'failure' }}
+    needs: [build, build-additional-cpu-arches]
     permissions: write-all
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/appimage-nightly.yml
+++ b/.github/workflows/appimage-nightly.yml
@@ -36,22 +36,21 @@ jobs:
           name: AppImage-${{ matrix.arch }}
           path: dist
 
-  # riscv64, loongarch64, ppc64le and ppc64 have no native runners, they build
-  # in the same container under qemu user emulation. comment out a line in the
-  # matrix to drop one arch, or set `if:` to false to turn the whole job off
+  # this part runs via QEMU so expect higher CI times
   build-additional-cpu-arches:
-    if: true
+    if: false # set to true to build the below arches
     name: "${{ matrix.name }} (${{ matrix.arch }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
+          # comment out the arches that are not wanted
+          # note 'if: false' is set by default and these are all turned off
           - { name: Build AppImage, arch: riscv64, platform: linux/riscv64 }
           - { name: Build AppImage, arch: loongarch64, platform: linux/loong64 }
           - { name: Build AppImage, arch: ppc64le, platform: linux/ppc64le }
-          # powerpc64 is big endian, uname -m reports ppc64
-          - { name: Build AppImage, arch: ppc64, platform: linux/ppc64 }
+          - { name: Build AppImage, arch: ppc64, platform: linux/ppc64 } # BE
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build AppImage (emulated)
@@ -67,8 +66,7 @@ jobs:
           path: dist
 
   release:
-    # !cancelled() is what lets the release still happen when the job above is
-    # switched off, a skipped dependency otherwise skips this job too
+    # !cancelled() lets a release happen if build-additional-cpu-arches if turned off
     if: >-
       ${{ !cancelled() && github.ref_name == 'main'
       && needs.build.result == 'success'

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -32,22 +32,21 @@ jobs:
           name: AppImage-${{ matrix.arch }}
           path: dist
 
-  # riscv64, loongarch64, ppc64le and ppc64 have no native runners, they build
-  # in the same container under qemu user emulation. comment out a line in the
-  # matrix to drop one arch, or set `if:` to false to turn the whole job off
+  # this part runs via QEMU so expect higher CI times
   build-additional-cpu-arches:
-    if: true
+    if: false # set to true to build the below arches
     name: "${{ matrix.name }} (${{ matrix.arch }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
+          # comment out the arches that are not wanted
+          # note 'if: false' is set by default and these are all turned off
           - { name: Build AppImage, arch: riscv64, platform: linux/riscv64 }
           - { name: Build AppImage, arch: loongarch64, platform: linux/loong64 }
           - { name: Build AppImage, arch: ppc64le, platform: linux/ppc64le }
-          # powerpc64 is big endian, uname -m reports ppc64
-          - { name: Build AppImage, arch: ppc64, platform: linux/ppc64 }
+          - { name: Build AppImage, arch: ppc64, platform: linux/ppc64 } # BE
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build AppImage (emulated)
@@ -61,8 +60,7 @@ jobs:
           path: dist
 
   release:
-    # !cancelled() is what lets the release still happen when the job above is
-    # switched off, a skipped dependency otherwise skips this job too
+    # !cancelled() lets a release happen if build-additional-cpu-arches if turned off
     if: >-
       ${{ !cancelled() && github.ref_name == 'main'
       && needs.build.result == 'success'

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -14,18 +14,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs-on: ubuntu-latest
-            name: Build AppImage
-            arch: x86_64
-          # comment out these 3 lines if aarch64 is not wanted
-          - runs-on: ubuntu-24.04-arm
-            name: Build AppImage
-            arch: aarch64
+          - { runs-on: ubuntu-latest, name: Build AppImage, arch: x86_64 }
+          # comment out this line if aarch64 is not wanted
+          - { runs-on: ubuntu-24.04-arm, name: Build AppImage, arch: aarch64 }
     container: ghcr.io/pkgforge-dev/archlinux:latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Preparing Container
-        uses: pkgforge-dev/anylinux-setup-action@0964f2258d6c93d1391359978dde081fd8b3c6af # v2
+        uses: pkgforge-dev/anylinux-setup-action@7278cbb7c3692fce7241d427614ef7984192f138 # v3
       - name: Install Dependencies
         run: /bin/sh ./get-dependencies.sh
       - name: Make AppImage
@@ -36,9 +32,42 @@ jobs:
           name: AppImage-${{ matrix.arch }}
           path: dist
 
+  # riscv64, loongarch64, ppc64le and ppc64 have no native runners, they build
+  # in the same container under qemu user emulation. comment out a line in the
+  # matrix to drop one arch, or set `if:` to false to turn the whole job off
+  build-additional-cpu-arches:
+    if: true
+    name: "${{ matrix.name }} (${{ matrix.arch }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: Build AppImage, arch: riscv64, platform: linux/riscv64 }
+          - { name: Build AppImage, arch: loongarch64, platform: linux/loong64 }
+          - { name: Build AppImage, arch: ppc64le, platform: linux/ppc64le }
+          # powerpc64 is big endian, uname -m reports ppc64
+          - { name: Build AppImage, arch: ppc64, platform: linux/ppc64 }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Build AppImage (emulated)
+        uses: pkgforge-dev/anylinux-setup-action/emulated@7278cbb7c3692fce7241d427614ef7984192f138 # v3
+        with:
+          platform: ${{ matrix.platform }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: AppImage-${{ matrix.arch }}
+          path: dist
+
   release:
-    if: ${{ github.ref_name == 'main' }}
-    needs: [build]
+    # !cancelled() is what lets the release still happen when the job above is
+    # switched off, a skipped dependency otherwise skips this job too
+    if: >-
+      ${{ !cancelled() && github.ref_name == 'main'
+      && needs.build.result == 'success'
+      && needs.build-additional-cpu-arches.result != 'failure' }}
+    needs: [build, build-additional-cpu-arches]
     permissions: write-all
     runs-on: ubuntu-latest
     steps:

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -24,3 +24,6 @@ get-debloated-pkgs --add-common --prefer-nano
 # else
 # 	regular build steps
 # fi
+
+# Note that when building manually, you want to output the version of the
+# application to a ~/version file and remove VERSION from make-appimage.sh

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -8,9 +8,15 @@ echo "Installing package dependencies..."
 echo "---------------------------------------------------------------"
 # pacman -Syu --noconfirm PACKAGESHERE
 
-echo "Installing debloated packages..."
-echo "---------------------------------------------------------------"
-get-debloated-pkgs --add-common --prefer-nano
+# get-debloated-pkgs only ships x86_64 and aarch64 builds, the other arches
+# stay on the stock pacman packages until it grows them
+case "$ARCH" in
+	x86_64|aarch64)
+		echo "Installing debloated packages..."
+		echo "---------------------------------------------------------------"
+		get-debloated-pkgs --add-common --prefer-nano
+		;;
+esac
 
 # Comment this out if you need an AUR package
 #make-aur-package PACKAGENAME


### PR DESCRIPTION
Adds riscv64, loongarch64, ppc64le and ppc64 to the template, on top of the
`emulated` companion action added in pkgforge-dev/anylinux-setup-action#4.

GitHub has no native runners for these four, and they cannot use a job level
`container:` either, because the binfmt handlers have to be registered from a
step before such a container can start. So they get their own job that drives
the container through the action, and the existing `build` job is left alone
apart from the v3 pin.

### Turning arches on and off

Each matrix entry is one line, so dropping an arch is one `#`:

```yaml
          - { runs-on: ubuntu-latest, name: Build AppImage, arch: x86_64 }
          # comment out this line if aarch64 is not wanted
          - { runs-on: ubuntu-24.04-arm, name: Build AppImage, arch: aarch64 }
```

Turning the whole extra arch job off is `if: false` on the job. It cannot be
done by commenting the four matrix lines out, because an empty matrix is not an
empty job, it is an invalid workflow file, and then nothing runs at all, native
builds included. Measured, not assumed.

`release` needs `!cancelled()` to survive that switch, since a skipped
dependency otherwise skips the dependent job no matter what its `if:` says. The
extra conditions keep today's behaviour, a genuinely failing arch still holds
the release back. All four states were run:

```
if: true,  all pass     -> extra jobs run, release success, run green
if: false, no guard     -> extra skipped, release SKIPPED   (the bug)
if: false, with guard   -> extra skipped, release success, run green
if: true,  ppc64 fails  -> extra failed,  release skipped, run red
```

### get-debloated-pkgs

Gated on arch rather than removed. `get-debloated-pkgs` only ships x86_64 and
aarch64 builds, so the ported arches would fail on it, but commenting it out
wholesale would quietly drop debloated packages on the two arches where they
work today. The gate leaves those two byte for byte as they are and is one line
to widen later.

### Validation

Six arch matrix on a real application, Galculator, pinned to v3:
https://github.com/talaria0101/Galculator-AppImage/actions/runs/34573904813

x86_64, aarch64, riscv64, loongarch64 and ppc64le all green. ppc64 builds and
packs, then fails its runtime test on pkgforge-dev/Anylinux-sharun#11, which is
open and unrelated to this change. The previous hand rolled `docker run` step
fails ppc64 identically, same preload objects and same missing GLIBC_2.3 and 2.4
symbols, so no arch regresses here.

---
Requested by Samueru via errand.
Conversation: https://discord.com/channels/1313385177703256064/1547664011632578691
Transcript: https://talaria.qaidvoid.dev/?session=6a82hff
